### PR TITLE
Use mpromise explicitly

### DIFF
--- a/lib/v0/index.js
+++ b/lib/v0/index.js
@@ -1,4 +1,5 @@
 'use strict';
+var MPromise = require('mpromise');
 
 var pluginSpec = 'mongooseHookEnsureIndexes_2015_03';
 var pluginSpec_enabled = pluginSpec + '_enabled';
@@ -12,7 +13,7 @@ thisPlugin.ensureIndexes = function(cb) {
   // if the schema is not marked with this plugin, just use standard method.
   if (!this.schema[pluginSpec_enabled]) return props.ensureIndexesHooked.apply(this, arguments);
 
-  var promise = new props.mongoose.Promise(cb);
+  var promise = new MPromise(cb);
 
   var _this = this;
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "./lib/v0/index.js",
 
   "dependencies": {
+    "mpromise": "^0.5.5"
   },
 
   "bugs": {


### PR DESCRIPTION
This library uses `mongoose.Promise` but assumes it's `mpromise`.  This PR makes this dependency explicit, removing a crash that's present with current versions of Mongoose if `mpromise` is not used.